### PR TITLE
Refactors get_sid method to return service sid when user and group sid are not found

### DIFF
--- a/libraries/SecurityDescriptor.rb
+++ b/libraries/SecurityDescriptor.rb
@@ -60,6 +60,8 @@ class SecurityDescriptor < Inspec.resource(1)
     return group_sids[0][2] unless group_sids.empty?
     user_sids = inspec.command("wmic useraccount where 'Name=\"#{entity_name}\"' get Name\",\"SID /format:csv").stdout.strip.split("\r\n\r\n")[1..-1].map { |entry| entry.split(',') }
     return user_sids[0][2] unless user_sids.empty?
+    service_sids = inspec.command("sc.exe showSid \"#{entity_name}\" | Select-String -Pattern Service").stdout.strip.split("\r\n\r\n").map { |entry| entry.split(': ') }
+    return service_sids[0][1] unless service_sids.empty?
     entity_name
   end
 end


### PR DESCRIPTION
Signed-off-by: swapnil-patil96 <spatil@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Security Descriptor provides SID of Windows Services which are required for certain controls in the Stig Windows Server 2019 profile along with group and user SID

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

#4 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
